### PR TITLE
fix: Preserve boolean-like keys during YAML parsing

### DIFF
--- a/yamlql_library/loader.py
+++ b/yamlql_library/loader.py
@@ -30,7 +30,14 @@ class YamlLoader:
 
         # Pre-process the content to handle common multi-document formatting issues
         # Replace '------' with '---' and ensure separators are on their own lines
+        # Wrap boolean-like keys (on, true, etc.) in quotes to preserve them as strings
         processed_content = re.sub(r'^\s*-{3,}\s*$', '---', content, flags=re.MULTILINE)
+        boolean_keys = ['y', 'Y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO',
+                        'true', 'True', 'TRUE', 'false', 'False', 'FALSE',
+                        'on', 'On', 'ON', 'off', 'Off', 'OFF']
+        for key in boolean_keys:
+            # This regex finds keys at the start of a line and wraps them in quotes.
+            processed_content = re.sub(f'^{key}:', f'"{key}":', processed_content, flags=re.MULTILINE)
 
         # Use safe_load_all to handle multi-document YAML files
         documents = list(yaml.safe_load_all(processed_content))

--- a/yamlql_library/transformer.py
+++ b/yamlql_library/transformer.py
@@ -82,9 +82,14 @@ class DataTransformer:
             source_data = data_copy
 
         for table_name, value in source_data.items():
+            # Sanitize the table name to ensure it's a string. This handles
+            # YAML keys that are parsed as booleans (e.g., 'on') or numbers.
+            table_name = str(table_name)
+
             if isinstance(value, dict) and len(value) > 1:
                 # Create a separate table for each child if there are multiple children
                 for child_name, child_value in value.items():
+                    child_name = str(child_name)
                     if isinstance(child_value, dict) or isinstance(child_value, list):
                         tables.extend(self._normalize_records(f"{table_name}_{child_name}", [child_value]))
             elif isinstance(value, list) and value:


### PR DESCRIPTION
## Description
- Standard YAML parsers convert unquoted keys like on, yes, true, etc., into boolean values. This caused the application to crash when it attempted to create a database table with a non-string name.

## Fix
- This change introduces a pre-processing step in the YamlLoader that uses a regular expression to find and wrap these specific boolean-like keys in quotes before they are passed to the yaml.safe_load_all function.
- This ensures that keys like on: are correctly interpreted as the string "on" throughout the entire data transformation pipeline. 
